### PR TITLE
Make importanceFraction optional

### DIFF
--- a/src/Hydrator/Strategy/CropHintStrategy.php
+++ b/src/Hydrator/Strategy/CropHintStrategy.php
@@ -44,7 +44,7 @@ class CropHintStrategy implements StrategyInterface
             $cropHints[] = new CropHint(
                 $this->boundingPolyStrategy->hydrate($cropHintInfo['boundingPoly']),
                 isset($cropHintInfo['confidence']) ? $cropHintInfo['confidence'] : null,
-                $cropHintInfo['importanceFraction']
+                isset($cropHintInfo['importanceFraction']) ? $cropHintInfo['importanceFraction'] : null
             );
         }
 


### PR DESCRIPTION
Just a lil thing. Some responses don't contain the importanceFraction, resulting in obvious problems.