### PR TITLE
Added option to override version

### DIFF
--- a/src/Request/VisionRequest.php
+++ b/src/Request/VisionRequest.php
@@ -13,7 +13,13 @@ use Vision\Response\AnnotateImageResponse;
 
 class VisionRequest
 {
-    const VISION_ANNOTATE_PREFIX = 'https://vision.googleapis.com/v1/images:annotate?key=';
+    const VISION_VERSION = 'v1';
+    const VISION_ANNOTATE_PREFIX = 'https://vision.googleapis.com/' . self::VISION_VERSION . '/images:annotate?key=';
+
+    /**
+     * @var string
+     */
+    protected $version = self::VISION_VERSION;
 
     /**
      * @var string
@@ -59,13 +65,11 @@ class VisionRequest
         $this->imageContext = $imageContext ?: new ImageContext;
     }
 
-
     public function send()
     {
         try {
-            $client = new Client;
-            $response = $client->post(
-                self::VISION_ANNOTATE_PREFIX . $this->apiKey,
+            $response = (new Client)->post(
+                $this->getRequestUrl(),
                 [
                     'content-type' => 'application/json',
                     'body' => json_encode($this->getPayload()),
@@ -97,6 +101,23 @@ class VisionRequest
     public function getRawResponse()
     {
         return $this->rawResponse;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestUrl()
+    {
+        $visionUrl = self::VISION_ANNOTATE_PREFIX . $this->apiKey;
+        return str_replace('/' . self::VISION_VERSION . '/', '/' . $this->version . '/', $visionUrl);
+    }
+
+    /**
+     * @param string $version
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
     }
 
     /**
@@ -133,6 +154,9 @@ class VisionRequest
         );
     }
 
+    /**
+     * @return array
+     */
     protected function extractImageContext()
     {
         return array_filter(

--- a/src/Vision.php
+++ b/src/Vision.php
@@ -32,13 +32,24 @@ class Vision
     protected $imageContext;
 
     /**
+     * @var string
+     */
+    protected $version;
+
+    /**
      * @param string $apiKey
      * @param Feature[] $features
      * @param ImageContext|null $imageContext
+     * @param string $version
      */
-    public function __construct($apiKey, array $features = [], ImageContext $imageContext = null)
-    {
+    public function __construct(
+        $apiKey,
+        array $features = [],
+        ImageContext $imageContext = null,
+        $version = VisionRequest::VISION_VERSION
+    ) {
         $this->apiKey = $apiKey;
+        $this->version = $version;
         $this->setFeatures($features);
         $this->setImageContext($imageContext);
     }
@@ -46,11 +57,14 @@ class Vision
     /**
      * @param Image $image
      * @param string $responseType
-     * @return AnnotateImageResponse|string
+     * @return string|AnnotateImageResponse
      */
-    public function request(Image $image, $responseType = self::RESPONSE_TYPE_OBJECT)
-    {
+    public function request(
+        Image $image,
+        $responseType = self::RESPONSE_TYPE_OBJECT
+    ) {
         $this->visionRequest = new VisionRequest($this->apiKey, $image, $this->features, $this->imageContext);
+        $this->visionRequest->setVersion($this->version);
         $this->visionRequest->send();
 
         return $this->getResponseForType($responseType);


### PR DESCRIPTION
This PR adds the ability to override the default version. This can be useful when using experimental tagged features in the Cloud Vision request. 

Example:

```php
$vision = new \Vision\Vision(
    'api-key',
    [
        new \Vision\Feature(\Vision\Feature::SAFE_SEARCH_DETECTION, 100),
    ],
    null,
    'v1p1beta1'
);
```