### PR TITLE
Empty ImageContext array is not always acceptable

### DIFF
--- a/src/Request/VisionRequest.php
+++ b/src/Request/VisionRequest.php
@@ -145,7 +145,7 @@ class VisionRequest
                         $this->image->getType() => $this->image->getValue(),
                     ],
                     'features' => $this->getMappedFeatures(),
-                    'imageContext' => $this->extractImageContext()
+                    'imageContext' => $this->extractImageContext() ?: null
                 ],
             ],
         ];


### PR DESCRIPTION
Fixes #24 

Force nullable if array is empty