### PR TITLE
added source node when request contains an imageUri

### DIFF
--- a/src/Request/VisionRequest.php
+++ b/src/Request/VisionRequest.php
@@ -141,14 +141,21 @@ class VisionRequest
         return [
             'requests' => [
                 [
-                    'image' => [
-                        $this->image->getType() => $this->image->getValue(),
-                    ],
+                    'image' => $this->getImagePayload(),
                     'features' => $this->getMappedFeatures(),
                     'imageContext' => $this->extractImageContext() ?: null
                 ],
             ],
         ];
+    }
+
+    protected function getImagePayload()
+    {
+        $ret = [$this->image->getType() => $this->image->getValue()];
+        if('imageUri' == $this->image->getType()){
+            $ret = ['source' => $ret];
+        }
+        return $ret;
     }
 
     /**


### PR DESCRIPTION
Hi @jordikroon,
you did a good job:)

anyway according to the doc here https://cloud.google.com/vision/docs/request remote requests with imageUri need a source node and of course I did the fix after I had the error myself